### PR TITLE
Do not run pkgdown automatically

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -23,7 +23,7 @@ init_package <- function(pkg_name, path = ".", check_cran_name = TRUE) {
       stop("The package name ", pkg_name, " is already taken on CRAN.
            Consider choosing a different name.", call. = FALSE)
     }
-    }
+  }
 
   # at this point we create a new foder with the name
   new_path <- file.path(normalizePath(path), pkg_name)
@@ -93,7 +93,8 @@ init_package <- function(pkg_name, path = ".", check_cran_name = TRUE) {
       }
     }
     while(!valid_name(vignette_name <-
-                      ask("Please enter a name for the vignette:", type_fun = handle_answer))) {
+                      ask("Please enter a name for the vignette:",
+                          type_fun = handle_answer))) {
 
     }
     # remove ending .Rmd
@@ -166,8 +167,10 @@ init_package <- function(pkg_name, path = ".", check_cran_name = TRUE) {
   doc_path <- file.path(path, "docs")
   if (!dir.exists(doc_path) &&
       ask_yesno("Generate pkgdown website in docs folder?")) {
-    message("* Generate pkgdown website")
-    pkgdown::build_site(pkg = path, path = doc_path)
+    # pkgdown produces a .Rbuildignore in the current wd
+    # so for now we only print the command
+    message(crayon::bold("After setting up your package, call",
+            "`pkgdown::build_site()` in the package root."))
   }
 
   # compile readme if it exists
@@ -178,7 +181,7 @@ init_package <- function(pkg_name, path = ".", check_cran_name = TRUE) {
   }
 
   message("All done! ", praise::praise())
-  }
+}
 
 write_template <- function(tpl_name, path,
                            parameters = list(),

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,6 @@ Please note that using `Rscript` creates all optional components (like the MIT l
 * Adds a default `.lintr` file
 * Adds a `NEWS.md` file
 * Runs `devtools::document()`
-* Creates a `pkgdown` `docs` folder
 
 ### Package checks
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Please note that using `Rscript` creates all optional components (like the MIT l
 -   Adds a default `.lintr` file
 -   Adds a `NEWS.md` file
 -   Runs `devtools::document()`
--   Creates a `pkgdown` `docs` folder
 
 ### Package checks
 
@@ -94,7 +93,7 @@ recontools::check_package(run_gp = FALSE)
 #>    ✓ Packages should use appveyor CI for Windows testing
 #> 
 #> Consider fixing the issues identified above.
-#> However, your package is already terrific!
+#> However, your package is already groovy!
 ```
 
 Inspiration

--- a/tests/testthat/.Rbuildignore
+++ b/tests/testthat/.Rbuildignore
@@ -1,1 +1,0 @@
-^/private/var/folders/mz/g_202xxj32b6r__57x3dmfkr0000gn/T/RtmpUYIfL6/fa5bb546c76e8eec755ef88378a99b7fc9028aee/mypackage/docs$

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -20,7 +20,6 @@ test_that("creates a default skeleton", {
   expect_exists(file.path(path, "NAMESPACE"))
   expect_exists(file.path(path, "NEWS.md"))
   expect_exists(file.path(path, "README.md"))
-  expect_exists(file.path(path, "docs", "index.html"))
   expect_true(devtools::build_vignettes(path))
 })
 


### PR DESCRIPTION
Currently pkgdown creates .Rbuildignore entries in the current wording directory that might not be correct. Therefore we switch to telling the user how he/she can generate a website.